### PR TITLE
Made form fields always be stacked on top of each other

### DIFF
--- a/src/blocks/Form/Component/index.tsx
+++ b/src/blocks/Form/Component/index.tsx
@@ -160,7 +160,7 @@ export const FormBlock = ({ block, locale }: FormBlockProps) => {
           aria-label={form.title || 'Form'}
           noValidate
         >
-          <div className="grid grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 gap-6">
             {form.fields &&
               form.fields.map((field, index) => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/blocks/Form/Component/index.tsx
+++ b/src/blocks/Form/Component/index.tsx
@@ -160,7 +160,7 @@ export const FormBlock = ({ block, locale }: FormBlockProps) => {
           aria-label={form.title || 'Form'}
           noValidate
         >
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div className="grid grid-cols-2 gap-6">
             {form.fields &&
               form.fields.map((field, index) => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fin: Kattelin, että se palaute raadille tekstikenttä on ehkä nykysellään vähän hassun kapea pidemmälle viestille. Aattelin, että nykyään aihe ja teksti voisi olla päällekkäin kaikilla näytönleveyksillä. (Pls check et osasin lukee koodia oikein, tää on jotenkin tosi vaikeeselkosta mun silmiin😖)
<img width="1011" height="1060" alt="image" src="https://github.com/user-attachments/assets/ee3ccb14-e239-49bf-b7a8-f2c5096084d3" />
<img width="1010" height="843" alt="image" src="https://github.com/user-attachments/assets/9d08eb28-fdb4-4881-905d-772d206acdd9" />
